### PR TITLE
fix: new users did not have a journal

### DIFF
--- a/backend/mental_backend/api/views/journal_views.py
+++ b/backend/mental_backend/api/views/journal_views.py
@@ -62,9 +62,16 @@ class JournalDetailView(APIView):
     def get(self, request):
         journal = _get_user_journal_or_404(request.user)
         if not journal:
-            return Response(
-                {"error": "Journal not found."}, status=status.HTTP_404_NOT_FOUND
-            )
+            # Default Journal data
+            default_data = {
+                "owner": request.user.id,
+                "title": "My Journal",
+            }
+            serializer = JournalSerializer(data=default_data)
+            if serializer.is_valid():
+                serializer.save()
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         serializer = JournalSerializer(journal)
         return Response(serializer.data)
 

--- a/frontend/src/providers/AuthProvider.jsx
+++ b/frontend/src/providers/AuthProvider.jsx
@@ -24,10 +24,11 @@ export const AuthProvider = ({ children }) => {
       const accessToken = response.access;
       const refreshToken = response.refresh;
 
-      setAuth({ username, accessToken, refreshToken });
-      return true;
+      // state update is async and we need access to the auth object elsewhere
+      const authObject = { username, accessToken, refreshToken };
+      setAuth(authObject);
     } catch (error) {
-      console.error("Error: ", error);
+      throw new Error("Error: ", error)();
     }
   };
 

--- a/frontend/src/services/journalService.js
+++ b/frontend/src/services/journalService.js
@@ -1,5 +1,5 @@
 const JOURNAL_URL = import.meta.env.VITE_JOURNAL_API_URL;
-
+const JOURNAL_2_URL = import.meta.env.VITE_CREATE_JOURNAL_API_URL;
 import { authFetch } from "../util/authFetch";
 
 // Get the journal for the current user
@@ -15,7 +15,7 @@ const getJournal = async (auth, setAuth) => {
   if (response.ok) {
     return await response.json();
   } else {
-    throw new Error("Error fetching journal data.");
+    throw new Error(`Error fetching journal data. ${response.statusText}`);
   }
 };
 
@@ -37,7 +37,7 @@ const updateJournal = async (title, auth, setAuth) => {
   if (response.ok) {
     return await response.json();
   } else {
-    throw new Error("Error updating journal.");
+    throw new Error(`Error updating journal. ${response.statusText}`);
   }
 };
 


### PR DESCRIPTION
After logging in, the backend will look for a journal for the user. If there is not one to display the user's data, then it will be created at that time with default information. For example, a title of "My Journal".

closes #23 